### PR TITLE
RHMAP-6886 Added Service connection test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # testing-cloud-app
 
-Testing cloud application covering various parts of MBaaS APIs. 
-The basic usage is to deploy this application and access `/test` endpoint, 
-which will execute all tests and return results (in HTML or JSON format). 
-Tests can be executed individualy per each area or the MBaaS APIs can be 
+Testing cloud application covering various parts of MBaaS APIs.
+The basic usage is to deploy this application and access `/test` endpoint,
+which will execute all tests and return results (in HTML or JSON format).
+Tests can be executed individually per each area or the MBaaS APIs can be
 utilized directly via prepared endpoints.
 
 
@@ -13,6 +13,7 @@ utilized directly via prepared endpoints.
 - `GET /cache/test` execute Cache API tests
 - `GET /db/test` execute Database API tests
 - `GET /stats/test` execute Statistics API tests
+- `GET /service` execute Service connection test (Cloud App must have permissions to call the Service)
 
 
 #### Cache API endpoints

--- a/application.js
+++ b/application.js
@@ -30,6 +30,9 @@ app.use('/stats', require('./lib/stats.js').router());
 app.get('/test', function(req, res) {
   util.runTests(req, res, 'MBaaS API');
 });
+app.get('/service', function(req, res) {
+  util.testService(req, res);
+});
 
 var runtimeTimer = Date.now() / 1000;
 var startTime = new Date();

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,7 @@
 var util = require('util');
 var winston = require('winston');
 var Mocha = require('mocha');
+var fh = require('fh-mbaas-api');
 
 
 var mocha = new Mocha();
@@ -81,10 +82,10 @@ module.exports = {
   },
 
   runTests: function(req, res, apiName, grep) {
-    // it is not possible to run mocha repeatedly with different test files, 
-    // as workaround is used filtering via grep, see 
+    // it is not possible to run mocha repeatedly with different test files,
+    // as workaround is used filtering via grep, see
     // https://github.com/mochajs/mocha/issues/1938
-    // https://github.com/pghalliday/grunt-mocha-test/issues/108    
+    // https://github.com/pghalliday/grunt-mocha-test/issues/108
 
     winston.info('Running ' + apiName + ' tests');
 
@@ -106,6 +107,35 @@ module.exports = {
         res.json(runner.testResults);
       } else {
         res.send(report);
+      }
+    });
+  },
+  /**
+   * Function for testing connection between Cloud App and MBaaS Service
+   * @param req {object}  request
+   * @param req.body.guid GUID of MBaaS Service
+   * @param res {object}  response
+   */
+  testService: function(req, res) {
+    fh.service({
+      "guid": req.body.guid,
+      "path": "/hello",
+      "method": "POST",
+      headers: {
+         "Content-Type" : "application/json"
+      },
+      "params": {
+        "hello": "world"
+    }
+    }, function(err, body, serviceResponse) {
+      if ( err ) {
+        // An error occurred during the call to the service. log some debugging information
+        return res.json({ msg: 'service call failed - err : ' + err });
+      } else {
+        res.json({
+          msg: 'Got response from service: ' + JSON.stringify(body),
+          statusCode: serviceResponse.statusCode
+        });
       }
     });
   }


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/RHMAP-6886

This test can be launched by GET request method containing JSON data with Service GUID, so it's easy to use it from UARTs.
## How to test this?

Use [this](https://testing.zeta.feedhenry.com/#projects/v4pzuwm27qnmfwudppia3bkw/apps/v4pzuwoki7sdehbbkdc6lkaw/editor) cloud app.

You can use this piece of code to run it.

```
var request = require('request');
var cloudAppUrl = 'https://testing-v4pzuwoki7sdehbbkdc6lkaw-qed1-mbaas1-dev.mbaas1.zeta.feedhenry.com/';
var options = {
    url: cloudAppUrl + '/service',
    headers: {
        "Content-Type": "application/json",
    },
    json: {
        guid: "bqdpisj5che2tnknbcr7nmnv"
    }
};

request.get(options, function(err, res, body) {
  if (err) {
    console.log('error', error);
  } else {
    console.log('body', body);
  }
});
```

ping @AdamSaleh 
