### PR TITLE
RHMAP-6785 Fix of inability to re-run tests

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,14 +2,14 @@ var util = require('util');
 var winston = require('winston');
 var Mocha = require('mocha');
 var fh = require('fh-mbaas-api');
+var path = require('path');
 
-
-var mocha = new Mocha();
-mocha.ui('bdd');
-mocha.addFile('lib/cache_tests.js');
-mocha.addFile('lib/db_tests.js');
-mocha.addFile('lib/stats_tests.js');
-
+var mocha;
+var testFiles = [
+  'lib/cache_tests.js',
+  'lib/db_tests.js',
+  'lib/stats_tests.js'
+];
 
 function HTMLReporter(runner) {
   Mocha.reporters.Base.call(this, runner);
@@ -68,6 +68,18 @@ function initMochaGrep(grep, apiName) {
   }
 }
 
+function initMochaTestFiles() {
+  testFiles.forEach(function (testFile) {
+    mocha.addFile(testFile);
+  });
+}
+
+function deleteTestFilesFromCache() {
+  testFiles.forEach(function (testFile) {
+    var pathToTestFile = path.resolve(testFile);
+    delete require.cache[pathToTestFile];
+  });
+}
 
 module.exports = {
 
@@ -82,13 +94,12 @@ module.exports = {
   },
 
   runTests: function(req, res, apiName, grep) {
-    // it is not possible to run mocha repeatedly with different test files,
-    // as workaround is used filtering via grep, see
-    // https://github.com/mochajs/mocha/issues/1938
-    // https://github.com/pghalliday/grunt-mocha-test/issues/108
+    mocha = new Mocha();
+    mocha.ui('bdd');
+
 
     winston.info('Running ' + apiName + ' tests');
-
+    initMochaTestFiles();
     initMochaReporter(req);
     initMochaGrep(grep, apiName);
 
@@ -108,6 +119,7 @@ module.exports = {
       } else {
         res.send(report);
       }
+      deleteTestFilesFromCache();
     });
   },
   /**


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/RHMAP-6785
## Comments

The mysterious snag was in caching the test files ([known Mocha "issue"](https://github.com/mochajs/mocha/issues/736)) and instantiating mocha globally.
The fix includes new functions for adding test files to mocha and removing test files from node cache.
## Ping

@AdamSaleh @thradec 
