### PR TITLE
bump mbaas api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "body-parser": "~1.0.2",
     "cors": "~2.2.0",
     "express": "~4.0.0",
-    "fh-mbaas-api": "5.11.0",
+    "fh-mbaas-api": "5.12.14",
     "fh-component-metrics": "^2.0.1",
     "request": "~2.40.0",
     "mocha": "^2.1.0",
@@ -14,6 +14,7 @@
     "dummy-json": "^1.0.0"
   },
   "devDependencies": {
+    "grunt": "~0.4.2",
     "grunt-concurrent": "latest",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-watch": "latest",


### PR DESCRIPTION
Update testing-cloud-app to use new version of fh-mbaas-api.

Added a shrinkwrap file to deal with issues deploying to a dynoman mbaas.
