### PR TITLE
Fix secure tests for node 4

### DIFF
--- a/lib/secure_tests.js
+++ b/lib/secure_tests.js
@@ -65,7 +65,7 @@ describe('Secure API', function() {
       try {
         expect(err).to.not.exist;
         // Returns ciphertext as a Buffer object
-        expect(res.ciphertext).to.be.a('object');
+        expect(typeof res.ciphertext).to.be.equal('object');
         config.rsa.ciphertext = res.ciphertext;
         done();
       } catch (e) {
@@ -86,7 +86,7 @@ describe('Secure API', function() {
       try {
         expect(err).to.not.exist;
         // Returns plaintext as a Buffer object
-        expect(res.plaintext).to.be.a('object');
+        expect(typeof res.plaintext).to.be.equal('object');
         expect(res.plaintext.toString()).to.be.equal(config.plaintext);
         done();
       } catch (e) {


### PR DESCRIPTION
### Motivation

The 'chai' library uses the 'type-detect' library for type assertions.
More specifically, it uses the following code to figure out the type of an object when comparing for an assertion https://github.com/chaijs/type-detect/blob/1.0.0/lib/type.js#L27

However, this type detection results in different types when comparing a Buffer object on node 0.10 vs node 4

```
$ docker run --rm node:4 node -e "var reg = /^\[object (.*)\]$/; var buff = new Buffer(1); console.log(process.version, typeof buff, Object.prototype.toString.call(buff), Object.prototype.toString.call(buff).match(reg)[1].toLowerCase())"
v4.4.5 object [object Uint8Array] uint8array

$ docker run --rm node:0.10 node -e "var reg = /^\[object (.*)\]$/; var buff = new Buffer(1); console.log(process.version, typeof buff, Object.prototype.toString.call(buff), Object.prototype.toString.call(buff).match(reg)[1].toLowerCase())"
v0.10.45 object [object Object] object
```
### Modification

Change the object comparison to a more basic type check
### Result

The fh.sec tests pass for both node 0.10 & node 4
