### PR TITLE
Fixed bodyparser issue

### DIFF
--- a/application.js
+++ b/application.js
@@ -15,7 +15,9 @@ var securableEndpoints = [
 var app = express();
 
 app.use(cors());
-app.use(bodyParser());
+app.use(bodyParser.urlencoded({
+  extended: true
+}));
 
 app.use('/sys', mbaasExpress.sys(securableEndpoints));
 app.use('/mbaas', mbaasExpress.mbaas);


### PR DESCRIPTION
## Motivation

Fix of:

```
Thu, 23 Jun 2016 07:24:00 GMT body-parser deprecated bodyParser: use individual json/urlencoded middlewares at application.js:18:9
Thu, 23 Jun 2016 07:24:00 GMT body-parser deprecated undefined extended: provide extended option at node_modules/body-parser/index.js:105:29
```

According to http://stackoverflow.com/questions/24330014/bodyparser-is-deprecated-express-4

Ping @thradec 
