### PR TITLE
bump fh-mbaas-api to honor proxy env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "testing-cloud-app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "dependencies": {
     "body-parser": "~1.15.2",
     "cors": "~2.7.1",
     "express": "~4.14.0",
-    "fh-mbaas-api": "5.12.14",
+    "fh-mbaas-api": "6.1.3",
     "fh-component-metrics": "^2.0.1",
     "request": "~2.72.0",
     "mocha": "^2.1.0",


### PR DESCRIPTION
testing-cloud-app is failing on installation behind a HTTP proxy, this change makes the test start passing again.