### PR TITLE
add trailing slash to test

### DIFF
--- a/lib/host_tests.js
+++ b/lib/host_tests.js
@@ -8,7 +8,7 @@ var request = require('request');
  * @param done  {object}
  */
 function checkHostStatus(host, done) {
-  request.get(host, function(err, res) {
+  request.get(host + "/", function(err, res) {
     expect(err).to.not.exist;
     expect(res.statusCode).to.eql(200);
     done();


### PR DESCRIPTION
After discussing with @wtrocki we agreed the slash will work in either a proxied or unproxied environment.

Deployed with proxy here: 
https://proxy-route-rhmap-43-core.osm3.feedhenry.net/appdev2kro/test
And without proxy here:
https://appdevknx6.osm1.feedhenry.net/test