### PR TITLE
Fixed node6 aes encryption error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dummy-json": "^1.0.0",
     "express": "~4.14.0",
     "fh-component-metrics": "^2.0.1",
-    "fh-mbaas-api": "6.1.4",
+    "fh-mbaas-api": "7.0.14",
     "mocha": "^2.1.0",
     "request": "2.79.0",
     "winston": "^2.2.0"


### PR DESCRIPTION
Fixed in https://github.com/feedhenry/fh-security/pull/6