### PR TITLE
Changed path to bodytmp

### DIFF
--- a/lib/forms_tests.js
+++ b/lib/forms_tests.js
@@ -26,7 +26,7 @@ describe('Forms API', function() {
   var listenerRegistered;
 
   before(function() {
-    var defPath = path.resolve(__dirname, '../bodytmp.json');
+    var defPath = path.resolve('/tmp/bodytmp.json');
     definitions = JSON.parse(fs.readFileSync(defPath, 'utf8'));
   });
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -108,7 +108,7 @@ module.exports = {
     // form and theme in body -> save to a file
     var bodyFilePath;
     if (apiName === 'Forms API') {
-      bodyFilePath = path.resolve(__dirname, '../bodytmp.json');
+      bodyFilePath = path.resolve('/tmp/bodytmp.json');
       fs.writeFileSync(bodyFilePath, JSON.stringify(req.body));
       mocha.addFile('lib/forms_tests.js');
     }


### PR DESCRIPTION
*Motivation*

testing-cloud-app will stop working using new node10 and node8 runtimes that will appear in RHMAP 4.7.0 due to permission issues.

I changed the path to the bodytmp.json file for not so restricted location.

*How to test*
Ideally run mbaas-art core with these changes. Or deploy using all the runtimes manually.

