### PR TITLE
➖ Removed grunt-node-inspector dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-watch": "latest",
     "grunt-env": "~0.4.1",
-    "grunt-node-inspector": "~0.4.2",
     "grunt-nodemon": "0.4.2",
     "grunt-open": "~0.2.3",
     "grunt-plato": "~1.2.1",


### PR DESCRIPTION
Removed since it uses node-inspector which does not work for node 8 and later.

You can check https://github.com/ChrisWren/grunt-node-inspector/issues/42 for more info.