### PR TITLE
Add timeout to host test

### DIFF
--- a/lib/host_tests.js
+++ b/lib/host_tests.js
@@ -17,6 +17,7 @@ function checkHostStatus(host, done) {
 
 describe('Host API', function() {
   it('should get host URL', function(done) {
+    this.timeout(5000);
     fh.host(function(err, host) {
       try {
         expect(err).to.not.exist;


### PR DESCRIPTION
This is done in order to prevent this test from blocking whole test suite.